### PR TITLE
Dependency inversion principle - High-level modules should not depend…

### DIFF
--- a/app/src/main/java/com/ao/soliddesignprinciples/dependencyInversion/A.java
+++ b/app/src/main/java/com/ao/soliddesignprinciples/dependencyInversion/A.java
@@ -1,0 +1,16 @@
+package com.ao.soliddesignprinciples.dependencyInversion;
+
+/*Entities must depend on abstraction not concretion*/
+public class A {
+	private B b;
+	private C c;
+
+	public A() {
+		b = new B();    // inheritance oop
+		if (b == null) {
+
+		}
+		c = new C();
+		c.toString();        // object in class
+	}
+}

--- a/app/src/main/java/com/ao/soliddesignprinciples/dependencyInversion/B.java
+++ b/app/src/main/java/com/ao/soliddesignprinciples/dependencyInversion/B.java
@@ -1,0 +1,4 @@
+package com.ao.soliddesignprinciples.dependencyInversion;
+
+class B {
+}

--- a/app/src/main/java/com/ao/soliddesignprinciples/dependencyInversion/C.java
+++ b/app/src/main/java/com/ao/soliddesignprinciples/dependencyInversion/C.java
@@ -1,0 +1,4 @@
+package com.ao.soliddesignprinciples.dependencyInversion;
+
+class C {
+}


### PR DESCRIPTION
… on low-level modules. Both should depend on abstractions. Abstractions should not depend upon details. Details should depend upon abstractions.